### PR TITLE
chore: bump VFC rev to merged main (8316a50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=ecd5db4#ecd5db48e46857951ac42fe8f49bb53dd8e6c7d7"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=8316a50#8316a50d77aae45d846cd77a342a60ca5b0b1ef9"
 dependencies = [
  "base64",
  "chrono",
@@ -2341,7 +2341,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=ecd5db4#ecd5db48e46857951ac42fe8f49bb53dd8e6c7d7"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=8316a50#8316a50d77aae45d846cd77a342a60ca5b0b1ef9"
 dependencies = [
  "chrono",
  "serde",

--- a/packages/tee-core/Cargo.toml
+++ b/packages/tee-core/Cargo.toml
@@ -20,7 +20,7 @@ zeroize = { version = "1", features = ["derive"] }
 rand = "0.8"
 
 # VFC types (for TeeType re-export)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "ecd5db4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/packages/tee-relay/Cargo.toml
+++ b/packages/tee-relay/Cargo.toml
@@ -12,8 +12,8 @@ tee-core = { path = "../tee-core" }
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "ecd5db4" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "ecd5db4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
 
 # Web framework
 axum = "0.8"

--- a/packages/tee-verifier/Cargo.toml
+++ b/packages/tee-verifier/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types (receipt structures only)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "ecd5db4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
 
 # Crypto
 ed25519-dalek = { version = "2", features = ["rand_core"] }


### PR DESCRIPTION
## Summary

Updates VFC rev pin from `ecd5db4` (branch rev) to `8316a50` (merged main) now that VFC PR #30 (`user_data_hex`) has landed.

All 4 VFC deps updated consistently: tee-core, tee-relay (×2), tee-verifier.

## Test plan

- [x] `cargo test --workspace` — 52 tests passing
- [x] Cargo.lock committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)