### PR TITLE
chore(tee-verifier): remove dead QuoteUnverified, add #[non_exhaustive]

### DIFF
--- a/packages/tee-verifier/src/quote.rs
+++ b/packages/tee-verifier/src/quote.rs
@@ -4,6 +4,7 @@ use crate::result::AttestationStatus;
 
 /// Typed errors for quote verification failures.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum QuoteVerifyError {
     #[error("no quote field in tee_attestation")]
     MissingQuote,

--- a/packages/tee-verifier/src/result.rs
+++ b/packages/tee-verifier/src/result.rs
@@ -2,9 +2,8 @@ use crate::MeasurementEntry;
 use crate::quote::QuoteVerifyError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AttestationStatus {
-    /// No quote verification was attempted.
-    QuoteUnverified,
     /// Quote parsed and fields extracted, but platform signature not checked.
     /// The extracted fields were cross-checked against receipt claims.
     QuoteParsed,


### PR DESCRIPTION
## Summary

- Remove `AttestationStatus::QuoteUnverified` variant (no code path produces it after #19)
- Add `#[non_exhaustive]` to `AttestationStatus` and `QuoteVerifyError` so future variants don't break downstream matches

Post-merge cleanup from #19.

## Test plan

- [x] `cargo test --workspace` — 83 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)