### PR TITLE
docs(tee-verifier): document TranscriptBinding assurance levels

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -42,6 +42,30 @@ observe session plaintext even though they provision the infrastructure.
 - Operator can deny service (stop the relay, block network)
 - A compromised relay binary could exfiltrate data (mitigated by measurement)
 
+## Transcript binding assurance levels
+
+The verifier recomputes the transcript hash (SHA-512 over canonical JSON of all
+commitments) and compares it to a reference value from the receipt. The
+`TranscriptBinding` field in `TeeVerificationResult` records *which* reference
+was used, because the assurance levels differ significantly:
+
+| Binding | Source field | Assurance | When it occurs |
+|---------|-------------|-----------|----------------|
+| **UserData** | `tee_attestation.user_data_hex` | Hardware-bound — the hash is inside the SEV-SNP attestation report, signed by the platform. Proves the transcript was committed by code running in the measured CVM. | Real CVM with attestation support |
+| **TranscriptHashFallback** | `tee_attestation.transcript_hash_hex` | Relay-asserted — the hash is correct but set by the relay software, not bound into the attestation. A compromised relay could substitute a different hash without detection. | Simulated mode, or real CVM before `user_data` binding was deployed |
+| **None** | *(neither field present)* | Unverifiable — no reference exists to compare against. | Malformed or very old receipts |
+
+### Recommendations for callers
+
+- **Production verifiers** should require `TranscriptBinding::UserData`. Accept
+  `TranscriptHashFallback` only during a migration window when older receipts
+  are still in circulation.
+- **Display/debugging UIs** may show the binding level alongside the
+  `transcript_hash_valid` boolean so operators can triage assurance.
+- `is_valid()` and `is_valid_sans_quote()` check `transcript_hash_valid` but
+  do **not** enforce a minimum binding level — callers must check
+  `transcript_binding` themselves if they need hardware-bound assurance.
+
 ## Simulated mode caveats
 
 `SimulatedCvm` provides no hardware isolation. It exercises the same code

--- a/packages/tee-relay/src/session.rs
+++ b/packages/tee-relay/src/session.rs
@@ -170,7 +170,7 @@ impl SessionStore {
     }
 }
 
-/// Start a reaper task for an Arc<SessionStore>.
+/// Start a reaper task for an `Arc<SessionStore>`.
 ///
 /// If the session store mutex is poisoned, the reaper logs an error and
 /// exits the process. A service with a poisoned session store cannot safely

--- a/packages/tee-verifier/src/result.rs
+++ b/packages/tee-verifier/src/result.rs
@@ -44,13 +44,31 @@ pub enum AttestationHashStatus {
 }
 
 /// Which field the transcript hash was verified against.
+///
+/// The binding level determines the assurance that the transcript (the ordered
+/// set of commitments) was produced inside a genuine CVM:
+///
+/// | Variant | Assurance | What it means |
+/// |---------|-----------|---------------|
+/// | `UserData` | **Hardware-bound** | Transcript hash is in the SEV-SNP `user_data` field, which is included in the platform attestation report. A valid quote proves the hash was set by code running inside the measured CVM. |
+/// | `TranscriptHashFallback` | **Relay-asserted** | Transcript hash matches `transcript_hash_hex` in `tee_attestation`, but that field is set by the relay, not bound into the platform attestation. A compromised relay could substitute a different hash. |
+/// | `None` | **Unverifiable** | Neither `user_data_hex` nor `transcript_hash_hex` is present. The transcript cannot be verified against anything. |
+///
+/// Callers that check only `transcript_hash_valid == true` should also inspect
+/// `transcript_binding` — a valid hash with `TranscriptHashFallback` binding
+/// provides weaker assurance than one with `UserData` binding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TranscriptBinding {
-    /// Verified against platform `user_data_hex` (attestation-bound).
+    /// Transcript hash verified against the platform attestation `user_data`
+    /// field. This is the strongest binding: the hash was committed by code
+    /// running inside a measured CVM and is covered by the SEV-SNP signature.
     UserData,
-    /// Fell back to relay-asserted `transcript_hash_hex`.
+    /// Transcript hash verified against the relay-asserted `transcript_hash_hex`
+    /// field. The hash itself is correct, but it is not bound into the platform
+    /// attestation — a compromised relay could have substituted it.
     TranscriptHashFallback,
-    /// Neither field present.
+    /// Neither `user_data_hex` nor `transcript_hash_hex` was present in the
+    /// attestation. Transcript integrity cannot be verified.
     None,
 }
 
@@ -63,7 +81,7 @@ impl TeeVerificationResult {
 
     /// Returns `true` when all checks pass and the quote has been at minimum
     /// parsed and cross-checked against receipt claims. Accepts both
-    /// `QuoteParsed` and `QuoteVerified`. Use [`is_valid`] when full
+    /// `QuoteParsed` and `QuoteVerified`. Use [`Self::is_valid`] when full
     /// cryptographic chain verification is required.
     pub fn is_valid_parsed(&self) -> bool {
         matches!(


### PR DESCRIPTION
## Summary

- Add detailed rustdoc on `TranscriptBinding` enum explaining the security assurance hierarchy: `UserData` (hardware-bound) > `TranscriptHashFallback` (relay-asserted) > `None` (unverifiable)
- Add "Transcript binding assurance levels" section to `docs/threat-model.md` with comparison table and caller recommendations
- Fix two pre-existing doc warnings (unresolved `is_valid` link, unclosed HTML tag)

Closes #11

## Test plan

- [x] `cargo doc --workspace --no-deps` — zero warnings
- [x] `cargo test --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)