### PR TITLE
fix(tee-snp): SNP report version >= 2 and key derivation msg_version

### DIFF
--- a/packages/tee-snp/src/snp_guest.rs
+++ b/packages/tee-snp/src/snp_guest.rs
@@ -72,9 +72,9 @@ pub(crate) fn parse_report_bytes(report_bytes: &[u8]) -> Result<ParsedReport, Cv
             .try_into()
             .expect("4-byte slice"),
     );
-    if version != 2 {
+    if version < 2 {
         return Err(CvmError::AttestationUnavailable(format!(
-            "unsupported report version {version}, expected 2"
+            "unsupported report version {version}, expected >= 2"
         )));
     }
 
@@ -110,7 +110,7 @@ pub(crate) fn derive_seal_key(fw: &mut Firmware) -> Result<Zeroizing<[u8; 32]>, 
     );
 
     let key = fw
-        .get_derived_key(None, request)
+        .get_derived_key(Some(1), request)
         .map_err(|e| CvmError::SealError(format!("SNP_GET_DERIVED_KEY failed: {e}")))?;
 
     Ok(Zeroizing::new(key))
@@ -136,9 +136,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_report_rejects_wrong_version() {
+    fn parse_report_rejects_old_version() {
         let mut report = vec![0u8; 1184];
-        report[0..4].copy_from_slice(&99u32.to_le_bytes());
+        report[0..4].copy_from_slice(&1u32.to_le_bytes());
         assert!(parse_report_bytes(&report).is_err());
     }
 


### PR DESCRIPTION
## Summary

- Accept SNP report version >= 2 (was hardcoded to exactly 2). GCP N2D confidential VMs with kernel 6.17 return version 5; field layout at offsets 80/144 is stable across versions.
- Pin `get_derived_key` to msg_version 1 — msg_version >= 2 requires a launch mitigation vector parameter that we don't need.
- Update unit test to reject version 1 (too old) instead of version 99.

## Test plan

- [x] All 20 tests pass on GCP N2D (AMD Milan, SEV-SNP, kernel 6.17):
  - 12 unit tests (mock backend)
  - 3 golden report parsing tests
  - 5 live hardware tests (device open, identity, attestation, seal/unseal, keypair)
- [x] GCP VM deleted after validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)