### PR TITLE
fix: bind tee failure receipts to emitted transcript fields

### DIFF
--- a/packages/tee-relay/src/relay.rs
+++ b/packages/tee-relay/src/relay.rs
@@ -463,14 +463,16 @@ pub async fn build_failure_receipt_v2(
     let receipt_signing_pubkey_hex =
         receipt_core::public_key_to_hex(&state.signing_key.verifying_key());
 
-    // For failure receipts, use empty-string hash for missing fields
+    // Transcript binding must reflect the fields actually emitted in the
+    // receipt. Optional commitment fields omitted on the wire bind as "".
+    let missing_field = "";
     let empty_hash = hex::encode(Sha256::digest(b""));
 
     let transcript_inputs = TranscriptInputs {
         contract_hash,
-        prompt_template_hash: &empty_hash,
-        initiator_submission_hash: initiator_submission_hash.unwrap_or(&empty_hash),
-        responder_submission_hash: responder_submission_hash.unwrap_or(&empty_hash),
+        prompt_template_hash: missing_field,
+        initiator_submission_hash: initiator_submission_hash.unwrap_or(missing_field),
+        responder_submission_hash: responder_submission_hash.unwrap_or(missing_field),
         output_hash: &empty_hash,
         receipt_signing_pubkey_hex: &receipt_signing_pubkey_hex,
     };

--- a/packages/tee-relay/tests/relay_integration.rs
+++ b/packages/tee-relay/tests/relay_integration.rs
@@ -799,6 +799,31 @@ async fn relay_failure_receipt_on_provider_error() {
         receipt_core::canonicalize_serializable(&test_contract().output_schema).unwrap();
     let expected_hash = hex::encode(Sha256::digest(canonical.as_bytes()));
     assert_eq!(receipt.commitments.schema_hash, expected_hash);
+
+    let receipt_transcript_hex = tee_att
+        .transcript_hash_hex
+        .as_deref()
+        .expect("failure receipt transcript hash");
+    let recomputed = compute_transcript_hash(&TranscriptInputs {
+        contract_hash: &receipt.commitments.contract_hash,
+        prompt_template_hash: "",
+        initiator_submission_hash: receipt
+            .commitments
+            .initiator_submission_hash
+            .as_deref()
+            .unwrap_or(""),
+        responder_submission_hash: receipt
+            .commitments
+            .responder_submission_hash
+            .as_deref()
+            .unwrap_or(""),
+        output_hash: &receipt.commitments.output_hash,
+        receipt_signing_pubkey_hex: tee_att
+            .receipt_signing_pubkey_hex
+            .as_deref()
+            .expect("failure receipt signing pubkey"),
+    });
+    assert_eq!(receipt_transcript_hex, hex::encode(recomputed));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n- compute failure-receipt transcript bindings from the values actually emitted in receipt commitments\n- treat omitted optional commitment fields as empty strings instead of \n- add a relay integration regression test that recomputes the failure transcript from the receipt fields\n\n## Testing\n- cargo test -p tee-relay -p tee-verifier\n\nCloses #26