### PR TITLE
feat: reject contract-bound model profile hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=8316a50#8316a50d77aae45d846cd77a342a60ca5b0b1ef9"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=e1dcee4#e1dcee47c774d24d21fecd43f9e457956bf4a845"
 dependencies = [
  "base64",
  "chrono",
@@ -2488,7 +2488,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=8316a50#8316a50d77aae45d846cd77a342a60ca5b0b1ef9"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=e1dcee4#e1dcee47c774d24d21fecd43f9e457956bf4a845"
 dependencies = [
  "chrono",
  "serde",

--- a/packages/tee-core/Cargo.toml
+++ b/packages/tee-core/Cargo.toml
@@ -20,7 +20,7 @@ zeroize = { version = "1", features = ["derive"] }
 rand = "0.8"
 
 # VFC types (for TeeType re-export)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/packages/tee-relay/Cargo.toml
+++ b/packages/tee-relay/Cargo.toml
@@ -13,8 +13,8 @@ tee-snp = { path = "../tee-snp", optional = true }
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
 
 # Web framework
 axum = "0.8"

--- a/packages/tee-relay/src/echo.rs
+++ b/packages/tee-relay/src/echo.rs
@@ -63,6 +63,7 @@ pub async fn create_session(
         timing_class: None,
         metadata: serde_json::Value::Null,
         model_profile_id: None,
+        model_profile_hash: None,
         enforcement_policy_hash: None,
         output_schema_hash: None,
         model_constraints: None,

--- a/packages/tee-relay/src/relay.rs
+++ b/packages/tee-relay/src/relay.rs
@@ -117,9 +117,9 @@ fn validate_contract_support(
         }
     }
 
-    if contract.model_profile_id.is_some() {
+    if contract.model_profile_id.is_some() || contract.model_profile_hash.is_some() {
         return Err(RelayError::ContractValidation(
-            "model_profile_id is not supported by tee-relay".to_string(),
+            "model_profile_id/model_profile_hash are not supported by tee-relay".to_string(),
         ));
     }
 
@@ -230,9 +230,7 @@ pub async fn relay_core(
     };
 
     // 6. Compute prompt template hash (inline prompt program for now)
-    let prompt_template_hash = {
-        INLINE_PROMPT_TEMPLATE_HASH.to_string()
-    };
+    let prompt_template_hash = { INLINE_PROMPT_TEMPLATE_HASH.to_string() };
 
     // 7. Resolve effective max_tokens
     let effective_max_tokens = match contract.max_completion_tokens {

--- a/packages/tee-relay/src/session.rs
+++ b/packages/tee-relay/src/session.rs
@@ -290,6 +290,7 @@ mod tests {
                 timing_class: None,
                 metadata: serde_json::Value::Null,
                 model_profile_id: None,
+                model_profile_hash: None,
                 enforcement_policy_hash: None,
                 output_schema_hash: None,
                 model_constraints: None,

--- a/packages/tee-relay/tests/relay_integration.rs
+++ b/packages/tee-relay/tests/relay_integration.rs
@@ -80,6 +80,7 @@ fn test_contract() -> vault_family_types::Contract {
         timing_class: None,
         metadata: serde_json::Value::Null,
         model_profile_id: None,
+        model_profile_hash: None,
         enforcement_policy_hash: None,
         output_schema_hash: None,
         model_constraints: None,
@@ -1070,7 +1071,9 @@ async fn relay_plaintext_role_label_mismatch_aborts_session() {
         &session.session_id,
         &session.contract_hash,
         ParticipantRole::Initiator,
-        serde_json::to_vec(&mislabeled_init_input).unwrap().as_slice(),
+        serde_json::to_vec(&mislabeled_init_input)
+            .unwrap()
+            .as_slice(),
     );
     let init_resp = client
         .post(format!("{base}/sessions/{}/input", session.session_id))
@@ -1101,7 +1104,10 @@ async fn relay_plaintext_role_label_mismatch_aborts_session() {
     let output = poll_until_done(&client, &base, &session.session_id, &session.read_token).await;
     assert_eq!(output.state, tee_relay::session::SessionState::Aborted);
     let receipt = output.receipt_v2.expect("failure receipt");
-    assert_eq!(receipt.claims.status, Some(receipt_core::SessionStatus::Error));
+    assert_eq!(
+        receipt.claims.status,
+        Some(receipt_core::SessionStatus::Error)
+    );
 
     let status: SessionStatusResponse = client
         .get(format!("{base}/sessions/{}/status", session.session_id))
@@ -1128,7 +1134,10 @@ async fn relay_rejects_mismatched_relay_verifying_key() {
 
     assert_eq!(output.state, tee_relay::session::SessionState::Aborted);
     let receipt = output.receipt_v2.expect("failure receipt");
-    assert_eq!(receipt.claims.status, Some(receipt_core::SessionStatus::Error));
+    assert_eq!(
+        receipt.claims.status,
+        Some(receipt_core::SessionStatus::Error)
+    );
 }
 
 #[tokio::test]
@@ -1139,6 +1148,20 @@ async fn relay_rejects_unsupported_model_profile_id() {
 
     let mut contract = test_contract();
     contract.model_profile_id = Some("profile-1".to_string());
+    let session = create_session(&client, &base, contract).await;
+    let output = submit_both_inputs_and_wait_for_abort(&client, &base, &session).await;
+
+    assert_eq!(output.state, tee_relay::session::SessionState::Aborted);
+}
+
+#[tokio::test]
+async fn relay_rejects_unsupported_model_profile_hash() {
+    let mock_url = start_mock_provider(r#"{"decision":"HALT"}"#).await;
+    let base = start_relay_server(&mock_url).await;
+    let client = reqwest::Client::new();
+
+    let mut contract = test_contract();
+    contract.model_profile_hash = Some("f".repeat(64));
     let session = create_session(&client, &base, contract).await;
     let output = submit_both_inputs_and_wait_for_abort(&client, &base, &session).await;
 

--- a/packages/tee-verifier/Cargo.toml
+++ b/packages/tee-verifier/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types (receipt structures only)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "8316a50" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
 
 # Crypto
 ed25519-dalek = { version = "2", features = ["rand_core"] }


### PR DESCRIPTION
## Summary
- bump the `vault-family-core` pin to the new contract type
- reject `model_profile_id` / `model_profile_hash` bindings consistently in `tee-relay`
- add regression coverage for hash-only profile binding

## Validation
- `cargo test -p tee-relay unsupported_model_profile --tests`

Depends on vcav-io/vault-family-core#42
Refs vcav-io/agentvault#247