### PR TITLE
feat: wire VCEK cert through attestation pipeline (Wave 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=e1dcee4#e1dcee47c774d24d21fecd43f9e457956bf4a845"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=eb991eb#eb991eb3734c77cc21ec1553ba490989c1fe4378"
 dependencies = [
  "base64",
  "chrono",
@@ -2794,7 +2794,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core.git?rev=e1dcee4#e1dcee47c774d24d21fecd43f9e457956bf4a845"
+source = "git+https://github.com/vcav-io/vault-family-core.git?rev=eb991eb#eb991eb3734c77cc21ec1553ba490989c1fe4378"
 dependencies = [
  "chrono",
  "serde",

--- a/packages/tee-core/Cargo.toml
+++ b/packages/tee-core/Cargo.toml
@@ -20,7 +20,7 @@ zeroize = { version = "1", features = ["derive"] }
 rand = "0.8"
 
 # VFC types (for TeeType re-export)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "eb991eb" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/packages/tee-core/src/attestation.rs
+++ b/packages/tee-core/src/attestation.rs
@@ -118,6 +118,7 @@ impl CvmRuntime for SimulatedCvm {
             measurement: self.identity.measurement.clone(),
             quote,
             user_data: *user_data,
+            vcek_cert_der: None,
         })
     }
 

--- a/packages/tee-core/src/types.rs
+++ b/packages/tee-core/src/types.rs
@@ -37,6 +37,10 @@ pub struct AttestationReport {
     /// Transcript hash bound into the attestation via the platform's
     /// user_data field (64 bytes for SEV-SNP).
     pub user_data: [u8; 64],
+    /// DER-encoded VCEK certificate extracted from the SEV-SNP extended
+    /// attestation report's certificate chain. `None` for simulated CVMs
+    /// or if the hypervisor did not provide certificates.
+    pub vcek_cert_der: Option<Vec<u8>>,
 }
 
 /// Role of a session participant, used for AAD construction.

--- a/packages/tee-relay/Cargo.toml
+++ b/packages/tee-relay/Cargo.toml
@@ -13,8 +13,8 @@ tee-snp = { path = "../tee-snp", optional = true }
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "eb991eb" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "eb991eb" }
 
 # Web framework
 axum = "0.8"

--- a/packages/tee-relay/src/handlers.rs
+++ b/packages/tee-relay/src/handlers.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::header::AUTHORIZATION;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
+use axum::http::header::AUTHORIZATION;
 use axum::response::IntoResponse;
 use rand::RngCore;
 use rand::rngs::OsRng;

--- a/packages/tee-relay/src/relay.rs
+++ b/packages/tee-relay/src/relay.rs
@@ -439,6 +439,9 @@ async fn build_tee_receipt_v2(
             receipt_signing_pubkey_hex: Some(receipt_signing_pubkey_hex.clone()),
             transcript_hash_hex: Some(transcript_hash_hex.clone()),
             user_data_hex: Some(transcript_hash_hex),
+            snp_vcek_cert: report
+                .vcek_cert_der
+                .map(|b| base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &b)),
         }),
     };
 
@@ -565,6 +568,9 @@ pub async fn build_failure_receipt_v2(
             receipt_signing_pubkey_hex: Some(receipt_signing_pubkey_hex.clone()),
             transcript_hash_hex: Some(transcript_hash_hex.clone()),
             user_data_hex: Some(transcript_hash_hex),
+            snp_vcek_cert: report
+                .vcek_cert_der
+                .map(|b| base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &b)),
         }),
     };
 

--- a/packages/tee-snp/src/lib.rs
+++ b/packages/tee-snp/src/lib.rs
@@ -1,4 +1,4 @@
-mod snp_guest;
 pub mod runtime;
+mod snp_guest;
 
 pub use runtime::SevSnpCvm;

--- a/packages/tee-snp/src/runtime.rs
+++ b/packages/tee-snp/src/runtime.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::Zeroizing;
 
-use tee_core::attestation::{CvmError, CvmRuntime};
-use tee_core::types::{AttestationReport, EnclaveIdentity};
 #[cfg(any(target_os = "linux", test))]
 use tee_core::TeeType;
+use tee_core::attestation::{CvmError, CvmRuntime};
+use tee_core::types::{AttestationReport, EnclaveIdentity};
 
 #[cfg(target_os = "linux")]
 use crate::snp_guest;
@@ -107,9 +107,9 @@ impl SevSnpCvm {
         match &self.inner {
             #[cfg(target_os = "linux")]
             SevSnpInner::Hardware(fw) => {
-                let mut fw = fw.lock().map_err(|e| {
-                    CvmError::SealError(format!("firmware mutex poisoned: {e}"))
-                })?;
+                let mut fw = fw
+                    .lock()
+                    .map_err(|e| CvmError::SealError(format!("firmware mutex poisoned: {e}")))?;
                 snp_guest::derive_seal_key(&mut fw)
             }
             #[cfg(test)]
@@ -143,6 +143,7 @@ impl CvmRuntime for SevSnpCvm {
                     measurement: parsed.measurement_hex,
                     quote: parsed.report_bytes,
                     user_data: parsed.user_data,
+                    vcek_cert_der: parsed.vcek_cert_der,
                 })
             }
             #[cfg(test)]
@@ -157,6 +158,7 @@ impl CvmRuntime for SevSnpCvm {
                     measurement: measurement.clone(),
                     quote: report,
                     user_data: *user_data,
+                    vcek_cert_der: None,
                 })
             }
             #[cfg(not(any(target_os = "linux", test)))]

--- a/packages/tee-snp/src/snp_guest.rs
+++ b/packages/tee-snp/src/snp_guest.rs
@@ -21,6 +21,7 @@ pub(crate) struct ParsedReport {
     pub report_bytes: Vec<u8>,
     pub measurement_hex: String,
     pub user_data: [u8; 64],
+    pub vcek_cert_der: Option<Vec<u8>>,
 }
 
 // Report layout constants (AMD SEV-SNP ABI spec).
@@ -47,13 +48,22 @@ pub(crate) fn get_ext_report(
     fw: &mut Firmware,
     user_data: &[u8; 64],
 ) -> Result<ParsedReport, CvmError> {
-    let (report_bytes, _certs) = fw
+    let (report_bytes, certs) = fw
         .get_ext_report(None, Some(*user_data), Some(0))
-        .map_err(|e| {
-            CvmError::AttestationUnavailable(format!("SNP_GET_EXT_REPORT failed: {e}"))
-        })?;
+        .map_err(|e| CvmError::AttestationUnavailable(format!("SNP_GET_EXT_REPORT failed: {e}")))?;
 
-    parse_report_bytes(&report_bytes)
+    let vcek_cert_der = certs
+        .as_ref()
+        .and_then(|entries| {
+            entries
+                .iter()
+                .find(|e| e.cert_type == sev::firmware::guest::CertType::VCEK)
+        })
+        .map(|e| e.data.clone());
+
+    let mut parsed = parse_report_bytes(&report_bytes)?;
+    parsed.vcek_cert_der = vcek_cert_der;
+    Ok(parsed)
 }
 
 /// Parse raw report bytes to extract measurement and user_data.
@@ -67,11 +77,7 @@ pub(crate) fn parse_report_bytes(report_bytes: &[u8]) -> Result<ParsedReport, Cv
         )));
     }
 
-    let version = u32::from_le_bytes(
-        report_bytes[0..4]
-            .try_into()
-            .expect("4-byte slice"),
-    );
+    let version = u32::from_le_bytes(report_bytes[0..4].try_into().expect("4-byte slice"));
     if version < 2 {
         return Err(CvmError::AttestationUnavailable(format!(
             "unsupported report version {version}, expected >= 2"
@@ -89,6 +95,7 @@ pub(crate) fn parse_report_bytes(report_bytes: &[u8]) -> Result<ParsedReport, Cv
         report_bytes: report_bytes.to_vec(),
         measurement_hex,
         user_data,
+        vcek_cert_der: None,
     })
 }
 
@@ -102,8 +109,7 @@ pub(crate) fn derive_seal_key(fw: &mut Firmware) -> Result<Zeroizing<[u8; 32]>, 
 
     let request = DerivedKey::new(
         false, // root_key_select: false = VCEK
-        gfs,
-        0,    // vmpl
+        gfs, 0,    // vmpl
         0,    // guest_svn
         0,    // tcb_version
         None, // launch_mit_vector

--- a/packages/tee-snp/tests/golden_reports.rs
+++ b/packages/tee-snp/tests/golden_reports.rs
@@ -24,7 +24,9 @@ fn golden_report_standard_fields() {
     let report = build_synthetic_report(&user_data, &measurement);
 
     let verifier = SevSnpQuoteVerifier::parsing_only();
-    let result = verifier.verify_quote(&report).expect("parse should succeed");
+    let result = verifier
+        .verify_quote(&report)
+        .expect("parse should succeed");
 
     assert_eq!(result.fields.user_data, user_data);
     assert_eq!(result.fields.measurement, hex::encode(measurement));
@@ -37,7 +39,9 @@ fn golden_report_measurement_extraction_matches_adapter() {
     let report = build_synthetic_report(&user_data, &measurement_bytes);
 
     let verifier = SevSnpQuoteVerifier::parsing_only();
-    let result = verifier.verify_quote(&report).expect("parse should succeed");
+    let result = verifier
+        .verify_quote(&report)
+        .expect("parse should succeed");
 
     // The verifier's measurement field must equal the hex encoding of the raw bytes.
     let expected_hex = hex::encode(measurement_bytes);

--- a/packages/tee-snp/tests/snp_live.rs
+++ b/packages/tee-snp/tests/snp_live.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "snp-live")]
 
-use tee_core::attestation::CvmRuntime;
 use tee_core::TeeType;
+use tee_core::attestation::CvmRuntime;
 use tee_snp::SevSnpCvm;
 
 #[test]

--- a/packages/tee-verifier/Cargo.toml
+++ b/packages/tee-verifier/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 tee-transcript = { path = "../tee-transcript" }
 
 # VFC types (receipt structures only)
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "e1dcee4" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core.git", rev = "eb991eb" }
 
 # Crypto
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/packages/tee-verifier/src/lib.rs
+++ b/packages/tee-verifier/src/lib.rs
@@ -19,4 +19,4 @@ pub use result::{
     TranscriptBinding,
 };
 pub use snp_chain::{ProductFamily, TcbPolicy, VerificationConfig};
-pub use verify::{VerifyError, verify_tee_receipt};
+pub use verify::{VerifyError, verify_tee_receipt, verify_tee_receipt_with_config};

--- a/packages/tee-verifier/src/verify.rs
+++ b/packages/tee-verifier/src/verify.rs
@@ -11,6 +11,7 @@ use crate::result::{
     AttestationHashStatus, AttestationStatus, SignatureStatus, TeeVerificationResult,
     TranscriptBinding,
 };
+use crate::snp_chain::{self, VerificationConfig};
 
 #[derive(Debug, thiserror::Error)]
 pub enum VerifyError {
@@ -24,6 +25,20 @@ pub fn verify_tee_receipt(
     receipt: &ReceiptV2,
     allowlist: &dyn TransparencySource,
     quote_verifier: &dyn QuoteVerifier,
+) -> Result<TeeVerificationResult, VerifyError> {
+    verify_tee_receipt_with_config(
+        receipt,
+        allowlist,
+        quote_verifier,
+        &VerificationConfig::default(),
+    )
+}
+
+pub fn verify_tee_receipt_with_config(
+    receipt: &ReceiptV2,
+    allowlist: &dyn TransparencySource,
+    quote_verifier: &dyn QuoteVerifier,
+    config: &VerificationConfig,
 ) -> Result<TeeVerificationResult, VerifyError> {
     let tee_att = receipt
         .tee_attestation
@@ -93,10 +108,32 @@ pub fn verify_tee_receipt(
     };
 
     // 2c. Chain verification: upgrade Parsed → ChainVerified when VCEK cert
-    // is available. Wave 2 adds TeeAttestation.snp_vcek_cert and
-    // verify_tee_receipt_with_config() to wire snp_chain::verify_snp_attestation
-    // into this flow. "Present but malformed" must be QuoteInvalid, not a
-    // silent fallback.
+    // is present. "Present but malformed" is QuoteInvalid, not silent fallback.
+    // "Absent" stays at Parsed.
+    let attestation_status = match (&attestation_status, &tee_att.snp_vcek_cert) {
+        (AttestationStatus::QuoteParsed, Some(vcek_b64)) => {
+            let b64 = base64::engine::general_purpose::STANDARD;
+            match b64.decode(vcek_b64) {
+                Err(_) => AttestationStatus::QuoteInvalid(QuoteVerifyError::ChainInvalid(
+                    "snp_vcek_cert base64 decode failed".into(),
+                )),
+                Ok(vcek_der) => {
+                    // quote_bytes: re-decode from tee_att.quote (already validated above)
+                    let quote_bytes = tee_att
+                        .quote
+                        .as_ref()
+                        .and_then(|q| b64.decode(q).ok())
+                        .unwrap_or_default();
+                    match snp_chain::verify_snp_attestation(&quote_bytes, &vcek_der, config) {
+                        Ok(()) => AttestationStatus::QuoteVerified,
+                        Err(e) => AttestationStatus::QuoteInvalid(e),
+                    }
+                }
+            }
+        }
+        (AttestationStatus::QuoteParsed, None) => attestation_status,
+        _ => attestation_status,
+    };
 
     // 3. Measurement allowlist (exact match)
     let measurement_match = allowlist.is_allowed(tee_att.measurement.as_deref().unwrap_or(""));

--- a/packages/tee-verifier/tests/verify_integration.rs
+++ b/packages/tee-verifier/tests/verify_integration.rs
@@ -147,6 +147,7 @@ fn build_receipt(quote_builder: QuoteBuilder) -> (ReceiptV2, SigningKey) {
             receipt_signing_pubkey_hex: Some(pubkey_hex),
             transcript_hash_hex: Some(transcript_hash_hex),
             user_data_hex: Some(user_data_hex),
+            snp_vcek_cert: None,
         }),
     };
 

--- a/packages/tee-verifier/tests/verify_integration.rs
+++ b/packages/tee-verifier/tests/verify_integration.rs
@@ -44,6 +44,13 @@ fn snp_quote_builder(measurement: [u8; 48]) -> QuoteBuilder {
 }
 
 fn build_receipt(quote_builder: QuoteBuilder) -> (ReceiptV2, SigningKey) {
+    build_receipt_with_vcek(quote_builder, None)
+}
+
+fn build_receipt_with_vcek(
+    quote_builder: QuoteBuilder,
+    snp_vcek_cert: Option<String>,
+) -> (ReceiptV2, SigningKey) {
     let mut rng = rand::thread_rng();
     let signing_key = SigningKey::generate(&mut rng);
     let pubkey_hex = receipt_core::public_key_to_hex(&signing_key.verifying_key());
@@ -147,7 +154,7 @@ fn build_receipt(quote_builder: QuoteBuilder) -> (ReceiptV2, SigningKey) {
             receipt_signing_pubkey_hex: Some(pubkey_hex),
             transcript_hash_hex: Some(transcript_hash_hex),
             user_data_hex: Some(user_data_hex),
-            snp_vcek_cert: None,
+            snp_vcek_cert,
         }),
     };
 
@@ -364,11 +371,125 @@ fn is_valid_sans_quote_ignores_attestation() {
 }
 
 // ---------------------------------------------------------------------------
-// SNP chain verification (direct snp_chain tests — Wave 1 contract)
+// SNP chain verification through verify_tee_receipt (Wave 2 — receipt-level)
 //
-// These test snp_chain::verify_snp_attestation directly since TeeAttestation
-// doesn't have snp_vcek_cert yet (Wave 2). They prove the verification model
-// works with synthetic cert hierarchies.
+// These test the step 2c code path in verify.rs: when snp_vcek_cert is present,
+// QuoteParsed should be upgraded to QuoteVerified (or QuoteInvalid on failure).
+// The positive path (QuoteParsed → QuoteVerified) requires a real AMD-signed VCEK
+// and is not testable with synthetic certs. The negative paths are all tested.
+// ---------------------------------------------------------------------------
+
+mod snp_vcek_receipt_tests {
+    use super::*;
+    use tee_verifier::{QuoteVerifyError, SevSnpQuoteVerifier};
+
+    #[test]
+    fn malformed_base64_vcek_cert_is_quote_invalid() {
+        // snp_vcek_cert present but not valid base64 → hard failure, not silent fallback
+        let snp_measurement = [0xBB_u8; 48];
+        let (receipt, _key) = build_receipt_with_vcek(
+            snp_quote_builder(snp_measurement),
+            Some("!!!not-valid-base64!!!".to_string()),
+        );
+        let allowlist = allowlist_with(&hex::encode(snp_measurement));
+        let verifier = SevSnpQuoteVerifier::parsing_only();
+
+        let result = verify_tee_receipt(&receipt, &allowlist, &verifier).unwrap();
+
+        assert!(
+            matches!(
+                result.attestation_status,
+                AttestationStatus::QuoteInvalid(QuoteVerifyError::ChainInvalid(ref msg))
+                    if msg.contains("base64 decode failed")
+            ),
+            "expected QuoteInvalid with base64 error, got: {:?}",
+            result.attestation_status
+        );
+        assert!(!result.is_valid());
+        assert!(!result.is_valid_parsed());
+    }
+
+    #[test]
+    fn garbage_der_vcek_cert_is_quote_invalid() {
+        // snp_vcek_cert decodes as base64 but is not valid DER → hard failure
+        let snp_measurement = [0xBB_u8; 48];
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let garbage_b64 = base64::Engine::encode(&b64, &[0xFF, 0xFE, 0xFD, 0xFC, 0xFB]);
+        let (receipt, _key) =
+            build_receipt_with_vcek(snp_quote_builder(snp_measurement), Some(garbage_b64));
+        let allowlist = allowlist_with(&hex::encode(snp_measurement));
+        let verifier = SevSnpQuoteVerifier::parsing_only();
+
+        let result = verify_tee_receipt(&receipt, &allowlist, &verifier).unwrap();
+
+        assert!(
+            matches!(
+                result.attestation_status,
+                AttestationStatus::QuoteInvalid(QuoteVerifyError::ChainInvalid(ref msg))
+                    if msg.contains("failed to parse VCEK")
+            ),
+            "expected QuoteInvalid with VCEK parse error, got: {:?}",
+            result.attestation_status
+        );
+        assert!(!result.is_valid());
+        assert!(!result.is_valid_parsed());
+    }
+
+    #[test]
+    fn self_signed_vcek_cert_unsupported_family() {
+        // Valid P-384 cert but not signed by any bundled AMD ASK → unsupported family
+        let snp_measurement = [0xBB_u8; 48];
+        let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+        let cert_params = rcgen::CertificateParams::new(vec!["test-vcek".into()]).unwrap();
+        let cert = cert_params.self_signed(&key_pair).unwrap();
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let vcek_b64 = base64::Engine::encode(&b64, cert.der());
+
+        let (receipt, _key) =
+            build_receipt_with_vcek(snp_quote_builder(snp_measurement), Some(vcek_b64));
+        let allowlist = allowlist_with(&hex::encode(snp_measurement));
+        let verifier = SevSnpQuoteVerifier::parsing_only();
+
+        let result = verify_tee_receipt(&receipt, &allowlist, &verifier).unwrap();
+
+        assert!(
+            matches!(
+                result.attestation_status,
+                AttestationStatus::QuoteInvalid(QuoteVerifyError::ChainInvalid(ref msg))
+                    if msg.contains("unsupported product family")
+            ),
+            "expected QuoteInvalid with unsupported family, got: {:?}",
+            result.attestation_status
+        );
+        assert!(!result.is_valid());
+        assert!(!result.is_valid_parsed());
+    }
+
+    #[test]
+    fn absent_vcek_cert_stays_parsed() {
+        // snp_vcek_cert: None → stays at QuoteParsed (no chain verification attempted)
+        let snp_measurement = [0xBB_u8; 48];
+        let (receipt, _key) = build_receipt_with_vcek(snp_quote_builder(snp_measurement), None);
+        let allowlist = allowlist_with(&hex::encode(snp_measurement));
+        let verifier = SevSnpQuoteVerifier::parsing_only();
+
+        let result = verify_tee_receipt(&receipt, &allowlist, &verifier).unwrap();
+
+        assert_eq!(
+            result.attestation_status,
+            AttestationStatus::QuoteParsed,
+            "absent vcek cert should leave status at QuoteParsed"
+        );
+        assert!(!result.is_valid());
+        assert!(result.is_valid_parsed());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SNP chain verification (direct snp_chain tests)
+//
+// These test snp_chain::verify_snp_attestation directly. They prove the
+// verification model works with synthetic cert hierarchies.
 // ---------------------------------------------------------------------------
 
 mod snp_chain_tests {


### PR DESCRIPTION
## Summary
- Plumbs VCEK DER certificate from SEV-SNP extended attestation through the full pipeline: `tee-snp` extracts it from the cert table, `tee-core` carries it in `AttestationReport`, `tee-relay` base64-encodes it into `TeeAttestation.snp_vcek_cert`
- Wires `snp_chain::verify_snp_attestation` into `verify_tee_receipt` via new `verify_tee_receipt_with_config()` — upgrades `QuoteParsed` → `QuoteVerified` when VCEK cert is present and chain validates
- Bumps VFC rev pins to `eb991eb` across all 4 deps (adds `snp_vcek_cert` field to `TeeAttestation`)

## Design decisions
- **"Present but malformed" = hard failure**: If `snp_vcek_cert` is present but base64-decoding or chain verification fails, the result is `QuoteInvalid`, not a silent fallback to `QuoteParsed`
- **"Absent" = stays Parsed**: Receipts without `snp_vcek_cert` (simulated CVMs, hypervisors that don't provide certs) remain at `QuoteParsed` — no regression
- **Thin wrapper pattern**: `verify_tee_receipt()` calls `verify_tee_receipt_with_config()` with `VerificationConfig::default()` — no breaking change for existing callers

## Test plan
- [x] All 118 workspace tests pass (no regressions)
- [x] `cargo fmt --all -- --check` clean
- [ ] CI passes (clippy has 2 pre-existing warnings in tee-relay unrelated to this PR)
- [ ] Manual: deploy to GCP N2D CVM and verify VCEK cert extraction + chain verification with real AMD hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)