### PR TITLE
fix: correct SEV-SNP report layout offsets per AMD ABI spec

### DIFF
--- a/packages/tee-snp/src/snp_guest.rs
+++ b/packages/tee-snp/src/snp_guest.rs
@@ -57,7 +57,7 @@ pub(crate) fn get_ext_report(
         .and_then(|entries| {
             entries
                 .iter()
-                .find(|e| e.cert_type == sev::firmware::guest::CertType::VCEK)
+                .find(|e| e.cert_type == sev::firmware::host::CertType::VCEK)
         })
         .map(|e| e.data.clone());
 

--- a/packages/tee-snp/tests/snp_live.rs
+++ b/packages/tee-snp/tests/snp_live.rs
@@ -46,3 +46,38 @@ fn session_keypair_generation() {
     let (pub2, _sec2) = cvm.derive_session_keypair().unwrap();
     assert_ne!(pub1.as_bytes(), pub2.as_bytes());
 }
+
+#[tokio::test]
+async fn vcek_cert_extracted_from_report() {
+    let cvm = SevSnpCvm::new().unwrap();
+    let user_data = [0xCCu8; 64];
+    let report = cvm.get_attestation(&user_data).await.unwrap();
+
+    let vcek_der = report
+        .vcek_cert_der
+        .as_ref()
+        .expect("hypervisor should provide VCEK cert in extended report");
+    assert!(
+        vcek_der.len() > 100,
+        "VCEK DER cert should be non-trivial, got {} bytes",
+        vcek_der.len()
+    );
+}
+
+#[tokio::test]
+async fn vcek_chain_verification_passes() {
+    use tee_verifier::{VerificationConfig, snp_chain};
+
+    let cvm = SevSnpCvm::new().unwrap();
+    let user_data = [0xDDu8; 64];
+    let report = cvm.get_attestation(&user_data).await.unwrap();
+
+    let vcek_der = report
+        .vcek_cert_der
+        .as_ref()
+        .expect("VCEK cert required for chain verification");
+
+    // Full chain: VCEK → ASK → ARK + report signature + TCB
+    snp_chain::verify_snp_attestation(&report.quote, vcek_der, &VerificationConfig::default())
+        .expect("VCEK chain verification should pass on real AMD hardware");
+}

--- a/packages/tee-verifier/src/snp_sig.rs
+++ b/packages/tee-verifier/src/snp_sig.rs
@@ -3,13 +3,22 @@ use p384::ecdsa::{Signature, VerifyingKey};
 
 use crate::quote::QuoteVerifyError;
 
-/// SEV-SNP attestation report layout constants.
+/// SEV-SNP attestation report layout constants (AMD SEV-SNP ABI spec rev 1.55+).
+///
+/// Report structure (1184 bytes total):
+///   0..4     version (u32)
+///   4..8     guest_svn (u32)
+///   8..16    policy (u64)        — bit 19 = DEBUG
+///  52..56    signature_algo (u32) — 1 = ECDSA P-384/SHA-384
+///  72..76    flags (u32)         — bit 0 = SIGNING_KEY (0=VCEK, 1=VLEK)
+/// 672..1184  signature structure: r[72] || s[72] || reserved[368]
 const SIGNED_REGION_END: usize = 672;
-const SIG_ALGO_OFFSET: usize = 672;
-const SIG_R_OFFSET: usize = 676;
-const SIG_S_OFFSET: usize = 748;
+const SIG_ALGO_OFFSET: usize = 52;
+const SIG_R_OFFSET: usize = 672;
+const SIG_S_OFFSET: usize = 744;
 const SIG_COMPONENT_LEN: usize = 72;
-const POLICY_OFFSET: usize = 24;
+const POLICY_OFFSET: usize = 8;
+const FLAGS_OFFSET: usize = 72;
 
 /// Expected ECDSA P-384 with SHA-384 algorithm identifier.
 const ECDSA_P384_SHA384: u32 = 1;
@@ -17,9 +26,12 @@ const ECDSA_P384_SHA384: u32 = 1;
 /// Verify the ECDSA P-384 signature on an SEV-SNP attestation report.
 ///
 /// The signed region is bytes 0..672 of the 1184-byte report.
-/// The signature (r, s) is stored in little-endian at offsets 676 and 748,
+/// The signature (r, s) is stored in little-endian at offsets 672 and 744,
 /// each zero-padded to 72 bytes. We reverse byte order and trim to 48 bytes
 /// (P-384 field element size) before constructing the signature.
+///
+/// The signature algorithm field is at offset 52 (in the report header),
+/// NOT inside the signature structure.
 pub fn verify_report_signature(
     report_bytes: &[u8],
     vcek_pubkey: &VerifyingKey,
@@ -70,22 +82,29 @@ pub fn verify_report_signature(
         .map_err(|e| QuoteVerifyError::ChainInvalid(format!("report signature invalid: {e}")))
 }
 
-/// Check report policy bits for security-critical flags.
+/// Check report policy and flags for security-critical bits.
+///
+/// POLICY (offset 8, u64): bit 19 = DEBUG (must be 0 for production).
+/// FLAGS (offset 72, u32): bit 0 = SIGNING_KEY (0=VCEK, 1=VLEK; must be 0).
 fn check_report_policy(report_bytes: &[u8]) -> Result<(), QuoteVerifyError> {
+    // FLAGS.SIGNING_KEY (bit 0): must be 0 (VCEK). 1 means VLEK.
+    let flags = u32::from_le_bytes(
+        report_bytes[FLAGS_OFFSET..FLAGS_OFFSET + 4]
+            .try_into()
+            .unwrap(),
+    );
+    if flags & 1 != 0 {
+        return Err(QuoteVerifyError::ChainInvalid(
+            "report signed with VLEK (FLAGS.SIGNING_KEY=1), only VCEK is accepted".into(),
+        ));
+    }
+
+    // POLICY.DEBUG (bit 19): must be 0 (production mode).
     let policy = u64::from_le_bytes(
         report_bytes[POLICY_OFFSET..POLICY_OFFSET + 8]
             .try_into()
             .unwrap(),
     );
-
-    // Bit 2: SIGNING_KEY — must be 0 (VCEK). 1 means VLEK.
-    if policy & (1 << 2) != 0 {
-        return Err(QuoteVerifyError::ChainInvalid(
-            "report signed with VLEK (bit 2 set), only VCEK is accepted".into(),
-        ));
-    }
-
-    // Bit 19: DEBUG — must be 0 (production mode).
     if policy & (1 << 19) != 0 {
         return Err(QuoteVerifyError::ChainInvalid(
             "report has DEBUG policy bit set (bit 19), rejecting non-production report".into(),
@@ -119,15 +138,23 @@ mod tests {
         // Version 2
         report[0..4].copy_from_slice(&2u32.to_le_bytes());
 
-        // Policy
+        // Policy (offset 8): bit 19 = DEBUG
         let mut policy: u64 = 0;
-        if vlek {
-            policy |= 1 << 2;
-        }
         if debug {
             policy |= 1 << 19;
         }
         report[POLICY_OFFSET..POLICY_OFFSET + 8].copy_from_slice(&policy.to_le_bytes());
+
+        // Flags (offset 72): bit 0 = SIGNING_KEY (0=VCEK, 1=VLEK)
+        let mut flags: u32 = 0;
+        if vlek {
+            flags |= 1;
+        }
+        report[FLAGS_OFFSET..FLAGS_OFFSET + 4].copy_from_slice(&flags.to_le_bytes());
+
+        // Signature algo = 1 (ECDSA P-384) — at offset 52, inside signed region
+        report[SIG_ALGO_OFFSET..SIG_ALGO_OFFSET + 4]
+            .copy_from_slice(&ECDSA_P384_SHA384.to_le_bytes());
 
         // Some user_data
         report[80..144].copy_from_slice(&[0xAA; 64]);
@@ -135,12 +162,9 @@ mod tests {
         // Measurement
         report[144..192].copy_from_slice(&[0xBB; 48]);
 
-        // Sign the first 672 bytes
+        // Sign the first 672 bytes (includes all header fields)
         let signed_region = &report[..SIGNED_REGION_END];
         let signature: Signature = signing_key.sign(signed_region);
-
-        // Signature algo = 1 (ECDSA P-384)
-        report[SIG_ALGO_OFFSET..SIG_ALGO_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
 
         // Encode r and s in little-endian, zero-padded to 72 bytes
         let sig_bytes = signature.to_bytes();

--- a/packages/tee-verifier/tests/verify_integration.rs
+++ b/packages/tee-verifier/tests/verify_integration.rs
@@ -557,11 +557,12 @@ mod snp_sig_tests {
     use rand::rngs::OsRng;
     use tee_verifier::{QuoteVerifyError, snp_sig};
 
-    const SIG_ALGO_OFFSET: usize = 672;
-    const SIG_R_OFFSET: usize = 676;
-    const SIG_S_OFFSET: usize = 748;
+    const SIG_ALGO_OFFSET: usize = 52;
+    const SIG_R_OFFSET: usize = 672;
+    const SIG_S_OFFSET: usize = 744;
     const SIG_COMPONENT_LEN: usize = 72;
-    const POLICY_OFFSET: usize = 24;
+    const POLICY_OFFSET: usize = 8;
+    const FLAGS_OFFSET: usize = 72;
     const SIGNED_REGION_END: usize = 672;
 
     fn be_to_le_padded(be_bytes: &[u8], pad_len: usize) -> Vec<u8> {
@@ -574,21 +575,29 @@ mod snp_sig_tests {
         let mut report = vec![0u8; 1184];
         report[0..4].copy_from_slice(&2u32.to_le_bytes());
 
+        // Policy (offset 8): bit 19 = DEBUG
         let mut policy: u64 = 0;
-        if vlek {
-            policy |= 1 << 2;
-        }
         if debug {
             policy |= 1 << 19;
         }
         report[POLICY_OFFSET..POLICY_OFFSET + 8].copy_from_slice(&policy.to_le_bytes());
+
+        // Signature algo (offset 52, inside signed region)
+        report[SIG_ALGO_OFFSET..SIG_ALGO_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
+
+        // Flags (offset 72): bit 0 = SIGNING_KEY (0=VCEK, 1=VLEK)
+        let mut flags: u32 = 0;
+        if vlek {
+            flags |= 1;
+        }
+        report[FLAGS_OFFSET..FLAGS_OFFSET + 4].copy_from_slice(&flags.to_le_bytes());
+
         report[80..144].copy_from_slice(&[0xAA; 64]);
         report[144..192].copy_from_slice(&[0xBB; 48]);
 
-        // Sign
+        // Sign (all header fields set before signing)
         let signed_region = &report[..SIGNED_REGION_END];
         let signature: Signature = signing_key.sign(signed_region);
-        report[SIG_ALGO_OFFSET..SIG_ALGO_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
         let sig_bytes = signature.to_bytes();
         report[SIG_R_OFFSET..SIG_R_OFFSET + SIG_COMPONENT_LEN]
             .copy_from_slice(&be_to_le_padded(&sig_bytes[..48], SIG_COMPONENT_LEN));


### PR DESCRIPTION
## Summary

- Fixed report layout constants in `snp_sig.rs` to match AMD SEV-SNP ABI spec rev 1.55
- Added live hardware tests for VCEK cert extraction and full chain verification
- Fixed `CertType` import path (`sev::firmware::host`, not `guest`)

### Offset fixes

| Constant | Before (wrong) | After (correct) | Reason |
|----------|----------------|-----------------|--------|
| `SIG_ALGO_OFFSET` | 672 | 52 | Signature algo is in report header, not in signature structure |
| `SIG_R_OFFSET` | 676 | 672 | Signature structure starts directly with r[72], no embedded algo |
| `SIG_S_OFFSET` | 748 | 744 | s follows r at 672+72=744 |
| `POLICY_OFFSET` | 24 | 8 | Policy is at offset 8 (after version + guest_svn) |
| SIGNING_KEY check | POLICY bit 2 | FLAGS (offset 72) bit 0 | SIGNING_KEY is in FLAGS field, not POLICY |

These were wrong in Wave 1 but synthetic tests didn't catch it because they write and read at the same offsets. Discovered via live hardware testing on GCP N2D (AMD Milan).

### Live hardware validation (GCP N2D, AMD Milan)

All 7 tests pass on real SEV-SNP hardware:
```
test device_opens ... ok
test identity_is_sev_snp ... ok
test attestation_report_binds_user_data ... ok
test session_keypair_generation ... ok
test seal_unseal_roundtrip ... ok
test vcek_cert_extracted_from_report ... ok
test vcek_chain_verification_passes ... ok
```

The critical new test `vcek_chain_verification_passes` proves:
1. GCP hypervisor populates VCEK cert in extended attestation report
2. Bundled Milan ARK/ASK chain validates the VCEK cert
3. ECDSA P-384 report signature verifies against VCEK public key
4. TCB policy check passes (bl=4, tee=0, snp=0, mc=0)

## Test plan

- [x] All 55 tee-verifier tests pass locally (33 unit + 22 integration)
- [x] All 7 live hardware tests pass on GCP N2D (AMD Milan, SEV-SNP)
- [x] `vcek_chain_verification_passes` confirms end-to-end VCEK chain verification
- [x] GCP VM deleted after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)