### PR TITLE
feat: bind model identity to transcript hash (v2)

### DIFF
--- a/packages/tee-core/src/lib.rs
+++ b/packages/tee-core/src/lib.rs
@@ -9,7 +9,10 @@ pub use crypto::{build_aad, decrypt_payload};
 
 // Re-export tee-transcript for backwards compatibility.
 pub use tee_transcript as transcript;
-pub use tee_transcript::{TRANSCRIPT_VERSION, TranscriptInputs, compute_transcript_hash};
+pub use tee_transcript::{
+    TRANSCRIPT_VERSION, TRANSCRIPT_VERSION_V2, TranscriptInputs, TranscriptInputsV2,
+    compute_transcript_hash, compute_transcript_hash_v2,
+};
 pub use types::{AttestationReport, EnclaveIdentity, EncryptedPayload};
 
 // Re-export VFC types used by consumers.

--- a/packages/tee-relay/src/echo.rs
+++ b/packages/tee-relay/src/echo.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use tee_core::attestation::CvmRuntime;
 use tee_core::crypto::{build_aad, decrypt_payload};
 use tee_core::types::ParticipantRole;
-use tee_transcript::{TranscriptInputs, compute_transcript_hash};
+use tee_transcript::{TranscriptInputsV2, compute_transcript_hash_v2};
 
 use crate::session::{Session, SessionStore};
 use crate::types::*;
@@ -268,16 +268,17 @@ async fn build_echo_response(
         hex::encode(h.finalize())
     };
 
-    let transcript_inputs = TranscriptInputs {
+    let transcript_inputs = TranscriptInputsV2 {
         contract_hash: &hex::encode(vec![0u8; 32]),
         prompt_template_hash: "echo-mode-no-template",
         initiator_submission_hash: initiator_sub_hash,
         responder_submission_hash: responder_sub_hash,
         output_hash: &output_hash,
         receipt_signing_pubkey_hex: &state.receipt_signing_pubkey_hex,
+        model_identity_asserted: "",
     };
 
-    let transcript_hash = compute_transcript_hash(&transcript_inputs);
+    let transcript_hash = compute_transcript_hash_v2(&transcript_inputs);
     let transcript_hash_hex = hex::encode(transcript_hash);
 
     let report = state

--- a/packages/tee-relay/src/echo.rs
+++ b/packages/tee-relay/src/echo.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use tee_core::attestation::CvmRuntime;
 use tee_core::crypto::{build_aad, decrypt_payload};
 use tee_core::types::ParticipantRole;
-use tee_transcript::{TranscriptInputsV2, compute_transcript_hash_v2};
+use tee_transcript::{TranscriptInputs, compute_transcript_hash};
 
 use crate::session::{Session, SessionStore};
 use crate::types::*;
@@ -268,17 +268,19 @@ async fn build_echo_response(
         hex::encode(h.finalize())
     };
 
-    let transcript_inputs = TranscriptInputsV2 {
+    // Echo mode stays on v1 transcript hash: there is no model invocation,
+    // and EchoTeeAttestation has no transcript version field, so switching
+    // to v2 would silently break consumers.
+    let transcript_inputs = TranscriptInputs {
         contract_hash: &hex::encode(vec![0u8; 32]),
         prompt_template_hash: "echo-mode-no-template",
         initiator_submission_hash: initiator_sub_hash,
         responder_submission_hash: responder_sub_hash,
         output_hash: &output_hash,
         receipt_signing_pubkey_hex: &state.receipt_signing_pubkey_hex,
-        model_identity_asserted: "",
     };
 
-    let transcript_hash = compute_transcript_hash_v2(&transcript_inputs);
+    let transcript_hash = compute_transcript_hash(&transcript_inputs);
     let transcript_hash_hex = hex::encode(transcript_hash);
 
     let report = state

--- a/packages/tee-relay/src/relay.rs
+++ b/packages/tee-relay/src/relay.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
 use tee_core::attestation::CvmRuntime;
-use tee_transcript::{TranscriptInputs, compute_transcript_hash};
+use tee_transcript::{TranscriptInputsV2, compute_transcript_hash_v2};
 
 use crate::error::RelayError;
 use crate::provider::ProviderRequest;
@@ -325,16 +325,20 @@ async fn build_tee_receipt_v2(
     let receipt_signing_pubkey_hex =
         receipt_core::public_key_to_hex(&state.signing_key.verifying_key());
 
-    // Build transcript hash for attestation binding
-    let transcript_inputs = TranscriptInputs {
+    // Compute model identity once — used for both transcript binding and claims
+    let model_identity_asserted = format!("anthropic/{model_id}");
+
+    // Build transcript hash for attestation binding (v2: includes model identity)
+    let transcript_inputs = TranscriptInputsV2 {
         contract_hash,
         prompt_template_hash,
         initiator_submission_hash,
         responder_submission_hash,
         output_hash,
         receipt_signing_pubkey_hex: &receipt_signing_pubkey_hex,
+        model_identity_asserted: &model_identity_asserted,
     };
-    let transcript_hash = compute_transcript_hash(&transcript_inputs);
+    let transcript_hash = compute_transcript_hash_v2(&transcript_inputs);
     let transcript_hash_hex = hex::encode(transcript_hash);
 
     // Get CVM attestation bound to transcript hash
@@ -409,7 +413,7 @@ async fn build_tee_receipt_v2(
             responder_submission_hash: Some(responder_submission_hash.to_string()),
         },
         claims: Claims {
-            model_identity_asserted: Some(format!("anthropic/{model_id}")),
+            model_identity_asserted: Some(model_identity_asserted),
             model_identity_attested: None,
             model_profile_hash_asserted: None,
             runtime_hash_asserted: None,
@@ -469,15 +473,16 @@ pub async fn build_failure_receipt_v2(
     let missing_field = "";
     let empty_hash = hex::encode(Sha256::digest(b""));
 
-    let transcript_inputs = TranscriptInputs {
+    let transcript_inputs = TranscriptInputsV2 {
         contract_hash,
         prompt_template_hash: missing_field,
         initiator_submission_hash: initiator_submission_hash.unwrap_or(missing_field),
         responder_submission_hash: responder_submission_hash.unwrap_or(missing_field),
         output_hash: &empty_hash,
         receipt_signing_pubkey_hex: &receipt_signing_pubkey_hex,
+        model_identity_asserted: missing_field,
     };
-    let transcript_hash = compute_transcript_hash(&transcript_inputs);
+    let transcript_hash = compute_transcript_hash_v2(&transcript_inputs);
     let transcript_hash_hex = hex::encode(transcript_hash);
 
     let report = state

--- a/packages/tee-relay/tests/relay_integration.rs
+++ b/packages/tee-relay/tests/relay_integration.rs
@@ -14,7 +14,7 @@ use tee_relay::handlers::{self, RelayState};
 use tee_relay::relay::AppState;
 use tee_relay::session::SessionStore;
 use tee_relay::types::*;
-use tee_transcript::{TranscriptInputs, compute_transcript_hash};
+use tee_transcript::{TranscriptInputsV2, compute_transcript_hash_v2};
 
 /// Start a mock Anthropic API server that returns an HTTP error.
 async fn start_failing_mock_provider(status_code: u16) -> String {
@@ -664,13 +664,19 @@ async fn relay_transcript_hash_matches_recomputed() {
         .as_ref()
         .expect("prompt_template_hash");
 
-    let recomputed = compute_transcript_hash(&TranscriptInputs {
+    let model_identity = receipt
+        .claims
+        .model_identity_asserted
+        .as_deref()
+        .unwrap_or("");
+    let recomputed = compute_transcript_hash_v2(&TranscriptInputsV2 {
         contract_hash: &receipt.commitments.contract_hash,
         prompt_template_hash,
         initiator_submission_hash: &init_ct_hash,
         responder_submission_hash: &resp_ct_hash,
         output_hash,
         receipt_signing_pubkey_hex: &info.receipt_signing_pubkey_hex,
+        model_identity_asserted: model_identity,
     });
 
     assert_eq!(receipt_transcript_hex, &hex::encode(recomputed));
@@ -805,7 +811,7 @@ async fn relay_failure_receipt_on_provider_error() {
         .transcript_hash_hex
         .as_deref()
         .expect("failure receipt transcript hash");
-    let recomputed = compute_transcript_hash(&TranscriptInputs {
+    let recomputed = compute_transcript_hash_v2(&TranscriptInputsV2 {
         contract_hash: &receipt.commitments.contract_hash,
         prompt_template_hash: "",
         initiator_submission_hash: receipt
@@ -823,6 +829,11 @@ async fn relay_failure_receipt_on_provider_error() {
             .receipt_signing_pubkey_hex
             .as_deref()
             .expect("failure receipt signing pubkey"),
+        model_identity_asserted: receipt
+            .claims
+            .model_identity_asserted
+            .as_deref()
+            .unwrap_or(""),
     });
     assert_eq!(receipt_transcript_hex, hex::encode(recomputed));
 }

--- a/packages/tee-transcript/src/lib.rs
+++ b/packages/tee-transcript/src/lib.rs
@@ -3,6 +3,7 @@
 use sha2::{Digest, Sha512};
 
 pub const TRANSCRIPT_VERSION: &str = "av-tee-transcript-v1";
+pub const TRANSCRIPT_VERSION_V2: &str = "av-tee-transcript-v2";
 
 /// Structured input for transcript hashing.
 ///
@@ -17,8 +18,22 @@ pub struct TranscriptInputs<'a> {
     pub receipt_signing_pubkey_hex: &'a str,
     // provider_id and model_id are intentionally excluded from transcript
     // binding in v1. They are attested via existing receipt claims fields.
-    // If future verification requires binding provider identity to the
-    // attestation, add them here and bump TRANSCRIPT_VERSION.
+    // Use TranscriptInputsV2 for model identity binding.
+}
+
+/// V2 transcript inputs — adds model identity binding to the attestation.
+///
+/// `model_identity_asserted` is the composite provider/model string
+/// (e.g. `"anthropic/claude-sonnet-4-5-20250929"`). Pass `""` when no
+/// model was invoked (failure receipts, echo mode).
+pub struct TranscriptInputsV2<'a> {
+    pub contract_hash: &'a str,
+    pub prompt_template_hash: &'a str,
+    pub initiator_submission_hash: &'a str,
+    pub responder_submission_hash: &'a str,
+    pub output_hash: &'a str,
+    pub receipt_signing_pubkey_hex: &'a str,
+    pub model_identity_asserted: &'a str,
 }
 
 /// Compute the 64-byte transcript hash for SEV-SNP `user_data` binding.
@@ -49,6 +64,39 @@ pub fn compute_transcript_hash(inputs: &TranscriptInputs) -> [u8; 64] {
         inputs.receipt_signing_pubkey_hex,
         inputs.responder_submission_hash,
         TRANSCRIPT_VERSION,
+    );
+
+    let mut hasher = Sha512::new();
+    hasher.update(canonical.as_bytes());
+    hasher.finalize().into()
+}
+
+/// V2 transcript hash — includes `model_identity_asserted` in the binding.
+///
+/// Same algorithm as v1 (SHA-512 of canonical JSON with sorted keys) but
+/// with an additional field and `TRANSCRIPT_VERSION_V2`.
+pub fn compute_transcript_hash_v2(inputs: &TranscriptInputsV2) -> [u8; 64] {
+    let canonical = format!(
+        concat!(
+            "{{",
+            "\"contract_hash\":\"{}\",",
+            "\"initiator_submission_hash\":\"{}\",",
+            "\"model_identity_asserted\":\"{}\",",
+            "\"output_hash\":\"{}\",",
+            "\"prompt_template_hash\":\"{}\",",
+            "\"receipt_signing_pubkey_hex\":\"{}\",",
+            "\"responder_submission_hash\":\"{}\",",
+            "\"version\":\"{}\"",
+            "}}"
+        ),
+        inputs.contract_hash,
+        inputs.initiator_submission_hash,
+        inputs.model_identity_asserted,
+        inputs.output_hash,
+        inputs.prompt_template_hash,
+        inputs.receipt_signing_pubkey_hex,
+        inputs.responder_submission_hash,
+        TRANSCRIPT_VERSION_V2,
     );
 
     let mut hasher = Sha512::new();
@@ -159,5 +207,78 @@ mod tests {
     fn hash_is_64_bytes() {
         let h = compute_transcript_hash(&sample_inputs());
         assert_eq!(h.len(), 64);
+    }
+
+    // ── V2 tests ──────────────────────────────────────────────────────
+
+    fn sample_inputs_v2() -> TranscriptInputsV2<'static> {
+        TranscriptInputsV2 {
+            contract_hash: "aaaa",
+            prompt_template_hash: "bbbb",
+            initiator_submission_hash: "cccc",
+            responder_submission_hash: "dddd",
+            output_hash: "eeee",
+            receipt_signing_pubkey_hex: "ffff",
+            model_identity_asserted: "anthropic/test-model",
+        }
+    }
+
+    #[test]
+    fn deterministic_v2_same_inputs_same_hash() {
+        let h1 = compute_transcript_hash_v2(&sample_inputs_v2());
+        let h2 = compute_transcript_hash_v2(&sample_inputs_v2());
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn sensitive_to_model_identity_asserted_change() {
+        let base = compute_transcript_hash_v2(&sample_inputs_v2());
+        let changed = compute_transcript_hash_v2(&TranscriptInputsV2 {
+            model_identity_asserted: "anthropic/different-model",
+            ..sample_inputs_v2()
+        });
+        assert_ne!(base, changed);
+    }
+
+    #[test]
+    fn v1_and_v2_differ_for_same_base_inputs() {
+        let v1 = compute_transcript_hash(&sample_inputs());
+        let v2 = compute_transcript_hash_v2(&TranscriptInputsV2 {
+            contract_hash: "aaaa",
+            prompt_template_hash: "bbbb",
+            initiator_submission_hash: "cccc",
+            responder_submission_hash: "dddd",
+            output_hash: "eeee",
+            receipt_signing_pubkey_hex: "ffff",
+            model_identity_asserted: "",
+        });
+        assert_ne!(
+            v1, v2,
+            "v1 and v2 must differ even with empty model_identity_asserted"
+        );
+    }
+
+    #[test]
+    fn v2_hash_is_64_bytes() {
+        let h = compute_transcript_hash_v2(&sample_inputs_v2());
+        assert_eq!(h.len(), 64);
+    }
+
+    #[test]
+    #[ignore] // Run manually: cargo test -p tee-transcript golden_bootstrap_v2 -- --ignored --nocapture
+    fn golden_bootstrap_v2() {
+        let hash = compute_transcript_hash_v2(&sample_inputs_v2());
+        println!("GOLDEN_HASH_V2={}", hex::encode(hash)); // SAFETY: no plaintext
+    }
+
+    #[test]
+    fn golden_fixture_parity_v2() {
+        let hash = compute_transcript_hash_v2(&sample_inputs_v2());
+        // Bootstrap: run golden_bootstrap_v2 to generate, then paste here
+        assert_eq!(
+            hex::encode(hash),
+            "2731b2be1576ab14e1f94543ccbd60ae8185591f9d097aec6536fd1fe5a281783933c46970696dd02891c7ca123adf0afcd7bb10bf2589fd76c3350a49c3dc65",
+            "golden v2 fixture changed — update TS verifier if this changes"
+        );
     }
 }

--- a/packages/tee-verifier/src/lib.rs
+++ b/packages/tee-verifier/src/lib.rs
@@ -16,7 +16,7 @@ pub use quote::{
 };
 pub use result::{
     AttestationHashStatus, AttestationStatus, SignatureStatus, TeeVerificationResult,
-    TranscriptBinding,
+    TranscriptBinding, TranscriptSchema,
 };
 pub use snp_chain::{ProductFamily, TcbPolicy, VerificationConfig};
 pub use verify::{VerifyError, verify_tee_receipt, verify_tee_receipt_with_config};

--- a/packages/tee-verifier/src/result.rs
+++ b/packages/tee-verifier/src/result.rs
@@ -14,6 +14,29 @@ pub enum AttestationStatus {
     QuoteInvalid(QuoteVerifyError),
 }
 
+/// Which transcript hash schema was used for verification.
+///
+/// | Variant | Model identity bound? |
+/// |---------|-----------------------|
+/// | `V2` | Yes — `model_identity_asserted` is part of the attested transcript hash |
+/// | `V1` | No — legacy receipt; model identity is a relay-asserted claim only |
+///
+/// `None` in `TeeVerificationResult::transcript_schema` means neither schema
+/// matched (transcript hash invalid).
+///
+/// **Caller guidance:** `transcript_hash_valid == true` with
+/// `transcript_schema == Some(V1)` means the transcript matched but model
+/// identity was NOT hardware-bound — it is only a relay-asserted claim.
+/// Callers that require model-identity binding MUST check for `Some(V2)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TranscriptSchema {
+    /// Transcript v2: `model_identity_asserted` is included in the hash.
+    V2,
+    /// Transcript v1 (legacy): `model_identity_asserted` is NOT in the hash.
+    /// Model identity is only a relay-asserted claim.
+    V1,
+}
+
 #[derive(Debug, Clone)]
 pub struct TeeVerificationResult {
     pub measurement_match: Option<MeasurementEntry>,
@@ -22,6 +45,11 @@ pub struct TeeVerificationResult {
     pub attestation_hash_status: AttestationHashStatus,
     pub transcript_hash_valid: bool,
     pub transcript_binding: TranscriptBinding,
+    /// Which transcript schema was used to verify the hash.
+    /// `Some(V2)` means model identity is hardware-bound.
+    /// `Some(V1)` means legacy — model identity is NOT in the transcript.
+    /// `None` means neither schema matched (transcript hash invalid).
+    pub transcript_schema: Option<TranscriptSchema>,
     pub submission_hashes_present: bool,
 }
 

--- a/packages/tee-verifier/src/verify.rs
+++ b/packages/tee-verifier/src/verify.rs
@@ -3,13 +3,15 @@ use ed25519_dalek::VerifyingKey;
 use sha2::{Digest, Sha256};
 
 use receipt_core::ReceiptV2;
-use tee_transcript::{TranscriptInputs, compute_transcript_hash};
+use tee_transcript::{
+    TranscriptInputs, TranscriptInputsV2, compute_transcript_hash, compute_transcript_hash_v2,
+};
 
 use crate::allowlist::TransparencySource;
 use crate::quote::{QuoteVerifier, QuoteVerifyError, cross_check_and_map};
 use crate::result::{
     AttestationHashStatus, AttestationStatus, SignatureStatus, TeeVerificationResult,
-    TranscriptBinding,
+    TranscriptBinding, TranscriptSchema,
 };
 use crate::snp_chain::{self, VerificationConfig};
 
@@ -139,7 +141,10 @@ pub fn verify_tee_receipt_with_config(
     let measurement_match = allowlist.is_allowed(tee_att.measurement.as_deref().unwrap_or(""));
 
     // 4. Recompute transcript hash, compare to user_data_hex
-    let (transcript_hash_valid, transcript_binding) = {
+    //
+    // Try v2 first (model identity bound), then fall back to v1 for legacy
+    // receipts. The `transcript_schema` field tells callers which schema matched.
+    let (transcript_hash_valid, transcript_binding, transcript_schema) = {
         let commitments = &receipt.commitments;
         let contract_hash = commitments.contract_hash.as_str();
         let prompt_template_hash = commitments.prompt_template_hash.as_deref().unwrap_or("");
@@ -153,8 +158,26 @@ pub fn verify_tee_receipt_with_config(
             .unwrap_or("");
         let output_hash = commitments.output_hash.as_str();
         let pubkey_hex = tee_att.receipt_signing_pubkey_hex.as_deref().unwrap_or("");
+        let model_id = receipt
+            .claims
+            .model_identity_asserted
+            .as_deref()
+            .unwrap_or("");
 
-        let inputs = TranscriptInputs {
+        // V2 hash (includes model_identity_asserted)
+        let v2_inputs = TranscriptInputsV2 {
+            contract_hash,
+            prompt_template_hash,
+            initiator_submission_hash: initiator_sub,
+            responder_submission_hash: responder_sub,
+            output_hash,
+            receipt_signing_pubkey_hex: pubkey_hex,
+            model_identity_asserted: model_id,
+        };
+        let v2_hex = hex::encode(compute_transcript_hash_v2(&v2_inputs));
+
+        // V1 hash (legacy, no model identity)
+        let v1_inputs = TranscriptInputs {
             contract_hash,
             prompt_template_hash,
             initiator_submission_hash: initiator_sub,
@@ -162,23 +185,53 @@ pub fn verify_tee_receipt_with_config(
             output_hash,
             receipt_signing_pubkey_hex: pubkey_hex,
         };
-        let computed = compute_transcript_hash(&inputs);
-        let computed_hex = hex::encode(computed);
+        let v1_hex = hex::encode(compute_transcript_hash(&v1_inputs));
 
         // Compare against user_data_hex (the platform attestation binding),
         // falling back to transcript_hash_hex with explicit tracking of which
         // field was used so callers can distinguish assurance levels.
-        let (hash_valid, binding) = match &tee_att.user_data_hex {
-            Some(user_data) => (computed_hex == *user_data, TranscriptBinding::UserData),
+        //
+        // Within each binding target, try v2 first then v1.
+        let (hash_valid, binding, schema) = match &tee_att.user_data_hex {
+            Some(user_data) => {
+                if v2_hex == *user_data {
+                    (
+                        true,
+                        TranscriptBinding::UserData,
+                        Some(TranscriptSchema::V2),
+                    )
+                } else if v1_hex == *user_data {
+                    (
+                        true,
+                        TranscriptBinding::UserData,
+                        Some(TranscriptSchema::V1),
+                    )
+                } else {
+                    (false, TranscriptBinding::UserData, None)
+                }
+            }
             None => match &tee_att.transcript_hash_hex {
-                Some(th) => (
-                    computed_hex == *th,
-                    TranscriptBinding::TranscriptHashFallback,
-                ),
-                None => (false, TranscriptBinding::None),
+                Some(th) => {
+                    if v2_hex == *th {
+                        (
+                            true,
+                            TranscriptBinding::TranscriptHashFallback,
+                            Some(TranscriptSchema::V2),
+                        )
+                    } else if v1_hex == *th {
+                        (
+                            true,
+                            TranscriptBinding::TranscriptHashFallback,
+                            Some(TranscriptSchema::V1),
+                        )
+                    } else {
+                        (false, TranscriptBinding::TranscriptHashFallback, None)
+                    }
+                }
+                None => (false, TranscriptBinding::None, None),
             },
         };
-        (hash_valid, binding)
+        (hash_valid, binding, schema)
     };
 
     // 5. Check submission hashes present
@@ -192,6 +245,7 @@ pub fn verify_tee_receipt_with_config(
         attestation_hash_status,
         transcript_hash_valid,
         transcript_binding,
+        transcript_schema,
         submission_hashes_present,
     })
 }

--- a/packages/tee-verifier/tests/verify_integration.rs
+++ b/packages/tee-verifier/tests/verify_integration.rs
@@ -8,10 +8,13 @@ use receipt_core::{
     InputCommitment, Operator, ReceiptV2, SCHEMA_VERSION_V2, SessionStatus, TeeAttestation,
     TeeType, TokenUsage, UnsignedReceiptV2, sign_and_assemble_receipt_v2,
 };
-use tee_transcript::{TranscriptInputs, compute_transcript_hash};
+use tee_transcript::{
+    TranscriptInputs, TranscriptInputsV2, compute_transcript_hash, compute_transcript_hash_v2,
+};
 use tee_verifier::{
     AttestationHashStatus, AttestationStatus, MeasurementEntry, QuoteVerifyError,
-    SevSnpQuoteVerifier, SimulatedQuoteVerifier, StaticAllowlist, verify_tee_receipt,
+    SevSnpQuoteVerifier, SimulatedQuoteVerifier, StaticAllowlist, TranscriptSchema,
+    verify_tee_receipt,
 };
 
 // ---------------------------------------------------------------------------
@@ -62,6 +65,123 @@ fn build_receipt_with_vcek(
     let initiator_sub_hash = hex::encode(Sha256::digest(b"test-initiator-input"));
     let responder_sub_hash = hex::encode(Sha256::digest(b"test-responder-input"));
 
+    let model_identity_asserted = "test-model";
+    let inputs = TranscriptInputsV2 {
+        contract_hash: &contract_hash,
+        prompt_template_hash: &prompt_template_hash,
+        initiator_submission_hash: &initiator_sub_hash,
+        responder_submission_hash: &responder_sub_hash,
+        output_hash: &output_hash,
+        receipt_signing_pubkey_hex: &pubkey_hex,
+        model_identity_asserted,
+    };
+    let transcript_hash = compute_transcript_hash_v2(&inputs);
+
+    let (quote_bytes, measurement) = quote_builder(&transcript_hash);
+
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let quote_b64 = b64.encode(&quote_bytes);
+    let attestation_hash = hex::encode(Sha256::digest(&quote_bytes));
+    let user_data_hex = hex::encode(transcript_hash);
+    let transcript_hash_hex = hex::encode(transcript_hash);
+    let operator_key_fingerprint = hex::encode(Sha256::digest(hex::decode(&pubkey_hex).unwrap()));
+
+    let unsigned = UnsignedReceiptV2 {
+        receipt_schema_version: SCHEMA_VERSION_V2.to_string(),
+        receipt_canonicalization: CANONICALIZATION_V2.to_string(),
+        receipt_id: "test-receipt-001".to_string(),
+        session_id: "test-session-001".to_string(),
+        issued_at: chrono::Utc::now(),
+        assurance_level: AssuranceLevel::SelfAsserted,
+        operator: Operator {
+            operator_id: "test-relay".to_string(),
+            operator_key_fingerprint,
+            operator_key_discovery: None,
+        },
+        commitments: Commitments {
+            contract_hash,
+            schema_hash,
+            output_hash,
+            input_commitments: vec![InputCommitment {
+                participant_id: "initiator".to_string(),
+                input_hash: initiator_sub_hash.clone(),
+                hash_alg: HashAlgorithm::Sha256,
+                canonicalization: "CANONICAL_JSON_V1".to_string(),
+            }],
+            assembled_prompt_hash: hex::encode(Sha256::digest(b"test-assembled-prompt")),
+            prompt_assembly_version: "1.0.0".to_string(),
+            output: Some(serde_json::json!({"score": 4})),
+            prompt_template_hash: Some(prompt_template_hash),
+            effective_config_hash: None,
+            preflight_bundle: None,
+            output_retrieval_uri: None,
+            output_media_type: None,
+            preflight_bundle_uri: None,
+            rejected_output_hash: None,
+            initiator_submission_hash: Some(initiator_sub_hash),
+            responder_submission_hash: Some(responder_sub_hash),
+        },
+        claims: Claims {
+            model_identity_asserted: Some(model_identity_asserted.to_string()),
+            model_identity_attested: None,
+            model_profile_hash_asserted: None,
+            runtime_hash_asserted: None,
+            runtime_hash_attested: None,
+            budget_enforcement_mode: Some(BudgetEnforcementMode::Enforced),
+            provider_latency_ms: Some(100),
+            token_usage: Some(TokenUsage {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                total_tokens: 150,
+            }),
+            relay_software_version: Some("0.1.0".to_string()),
+            status: Some(SessionStatus::Success),
+            signal_class: Some("SESSION_COMPLETED".to_string()),
+            execution_lane: Some(ExecutionLaneV2::Tee),
+            channel_capacity_bits_upper_bound: Some(3),
+            channel_capacity_measurement_version: Some(
+                CHANNEL_CAPACITY_MEASUREMENT_VERSION.to_string(),
+            ),
+            entropy_budget_bits: Some(128),
+            schema_entropy_ceiling_bits: Some(3),
+            budget_usage: Some(BudgetUsageV2 {
+                bits_used_before: 0,
+                bits_used_after: 3,
+                budget_limit: 128,
+            }),
+        },
+        provider_attestation: None,
+        tee_attestation: Some(TeeAttestation {
+            tee_type: Some(TeeType::Simulated),
+            measurement: Some(measurement),
+            quote: Some(quote_b64),
+            attestation_hash: Some(attestation_hash),
+            receipt_signing_pubkey_hex: Some(pubkey_hex),
+            transcript_hash_hex: Some(transcript_hash_hex),
+            user_data_hex: Some(user_data_hex),
+            snp_vcek_cert,
+        }),
+    };
+
+    let receipt = sign_and_assemble_receipt_v2(unsigned, &signing_key).unwrap();
+    (receipt, signing_key)
+}
+
+/// Build a receipt using the v1 transcript hash (no model identity in hash).
+/// Used to test verifier backward compatibility.
+fn build_v1_receipt(quote_builder: QuoteBuilder) -> (ReceiptV2, SigningKey) {
+    let mut rng = rand::thread_rng();
+    let signing_key = SigningKey::generate(&mut rng);
+    let pubkey_hex = receipt_core::public_key_to_hex(&signing_key.verifying_key());
+
+    let contract_hash = hex::encode(Sha256::digest(b"test-contract"));
+    let schema_hash = hex::encode(Sha256::digest(b"test-schema"));
+    let output_hash = hex::encode(Sha256::digest(b"test-output"));
+    let prompt_template_hash = hex::encode(Sha256::digest(b"test-prompt-template"));
+    let initiator_sub_hash = hex::encode(Sha256::digest(b"test-initiator-input"));
+    let responder_sub_hash = hex::encode(Sha256::digest(b"test-responder-input"));
+
+    // Use v1 transcript hash (no model_identity_asserted)
     let inputs = TranscriptInputs {
         contract_hash: &contract_hash,
         prompt_template_hash: &prompt_template_hash,
@@ -84,8 +204,8 @@ fn build_receipt_with_vcek(
     let unsigned = UnsignedReceiptV2 {
         receipt_schema_version: SCHEMA_VERSION_V2.to_string(),
         receipt_canonicalization: CANONICALIZATION_V2.to_string(),
-        receipt_id: "test-receipt-001".to_string(),
-        session_id: "test-session-001".to_string(),
+        receipt_id: "test-receipt-v1-001".to_string(),
+        session_id: "test-session-v1-001".to_string(),
         issued_at: chrono::Utc::now(),
         assurance_level: AssuranceLevel::SelfAsserted,
         operator: Operator {
@@ -154,7 +274,7 @@ fn build_receipt_with_vcek(
             receipt_signing_pubkey_hex: Some(pubkey_hex),
             transcript_hash_hex: Some(transcript_hash_hex),
             user_data_hex: Some(user_data_hex),
-            snp_vcek_cert,
+            snp_vcek_cert: None,
         }),
     };
 
@@ -190,6 +310,33 @@ fn simulated_receipt_full_verification() {
     assert!(result.is_valid_parsed());
     assert!(result.is_valid_sans_quote());
     assert_eq!(result.attestation_status, AttestationStatus::QuoteVerified);
+    assert_eq!(
+        result.transcript_schema,
+        Some(TranscriptSchema::V2),
+        "v2 receipt should report TranscriptSchema::V2"
+    );
+}
+
+#[test]
+fn v1_receipt_verifies_with_fallback() {
+    // Build a receipt using v1 transcript hash (no model_identity_asserted in hash).
+    // Verifier should fall back to v1 and report TranscriptSchema::V1.
+    let (receipt, _key) = build_v1_receipt(simulated_quote_builder());
+    let allowlist = allowlist_with(&simulated_measurement());
+    let verifier = SimulatedQuoteVerifier;
+
+    let result = verify_tee_receipt(&receipt, &allowlist, &verifier).unwrap();
+
+    assert!(
+        result.transcript_hash_valid,
+        "v1 transcript hash should verify via fallback"
+    );
+    assert_eq!(
+        result.transcript_schema,
+        Some(TranscriptSchema::V1),
+        "v1 receipt should report TranscriptSchema::V1"
+    );
+    assert!(result.is_valid(), "v1 receipt should still be fully valid");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `model_identity_asserted` to transcript hash computation via new `compute_transcript_hash_v2` / `TranscriptInputsV2`, closing the gap where a compromised relay could substitute a different model without detection (#40)
- Verifier tries v2 first, falls back to v1 for legacy receipts — no breaking change to existing receipt verification
- New `TranscriptSchema` enum (`V1`/`V2`) in verification result so callers can distinguish whether model identity was hardware-bound
- Relay computes `model_identity_asserted` once and uses it for both claims and transcript binding (no drift risk)

## Test plan

- [x] All 148 workspace tests pass (`cargo test --workspace`)
- [x] v1 golden fixture unchanged (backward compatibility)
- [x] New v2 golden fixture stable
- [x] `v1_receipt_verifies_with_fallback` — v1 receipt verifies with `TranscriptSchema::V1`
- [x] `simulated_receipt_full_verification` — v2 receipt reports `TranscriptSchema::V2`
- [x] Relay integration tests recompute v2 transcript hash from receipt fields
- [x] `cargo fmt --all -- --check` clean
- [ ] Note: 2 pre-existing clippy warnings on main (filed as #44)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)