### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/packages/tee-relay/src/relay.rs
+++ b/packages/tee-relay/src/relay.rs
@@ -130,12 +130,12 @@ fn validate_contract_support(
     }
 
     let inline_schema_hash = canonical_sha256(&contract.output_schema)?;
-    if let Some(expected_schema_hash) = contract.output_schema_hash.as_deref() {
-        if expected_schema_hash != inline_schema_hash {
-            return Err(RelayError::ContractValidation(
-                "output_schema_hash does not match inline output_schema".to_string(),
-            ));
-        }
+    if let Some(expected_schema_hash) = contract.output_schema_hash.as_deref()
+        && expected_schema_hash != inline_schema_hash
+    {
+        return Err(RelayError::ContractValidation(
+            "output_schema_hash does not match inline output_schema".to_string(),
+        ));
     }
 
     Ok(inline_schema_hash)

--- a/packages/tee-relay/src/session.rs
+++ b/packages/tee-relay/src/session.rs
@@ -48,6 +48,7 @@ pub struct Session {
 }
 
 impl Session {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_id_bytes: [u8; 16],
         contract_hash_bytes: Vec<u8>,


### PR DESCRIPTION
## Summary

- Collapse nested `if let` + `if` into let-chain in `validate_contract_support` (`collapsible_if`)
- Allow `too_many_arguments` on `Session::new` — struct has many fields by nature, builder would be over-engineering

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` all pass
- [x] `cargo fmt --all -- --check` clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)